### PR TITLE
order prices now match cart/bike prices when rendered

### DIFF
--- a/client/components/OrderCard.js
+++ b/client/components/OrderCard.js
@@ -32,8 +32,9 @@ const styles = theme => ({
 const OrderCard = ({items, classes}) =>
   items.map(item => {
     console.log(item)
+    const price = item.orderEntries.price/100.0
     return (
-      
+
       <TableRow key={item.id}>
         <TableCell
           component="th"
@@ -51,7 +52,7 @@ const OrderCard = ({items, classes}) =>
         <TableCell>
           <Link to={`/bikes/${item.id}`}>{item.name}</Link>
           <div><Typography variant="body2" gutterBottom>
-          ${item.orderEntries.price}
+          ${price}
         </Typography></div>
           <div><Typography variant="body2" gutterBottom>
           Quantity {item.orderEntries.quantity}

--- a/client/components/OrderHistory.js
+++ b/client/components/OrderHistory.js
@@ -46,7 +46,7 @@ const styles = theme => ({
     flexDirection: 'column'
   },
   darkColor: {
-    color: theme.palette.primary.dark 
+    color: theme.palette.primary.dark
   }
 })
 
@@ -61,6 +61,7 @@ class OrderHistory extends Component {
     return this.props.orders.length ? (
       <div className={classes.container}>
         {this.props.orders.map(order => {
+          const orderCost=order.orderCost/100.0
           return (
             <Paper className={classes.root} key={order.id}>
               <Table className={classes.table} key={order.id}>
@@ -77,7 +78,7 @@ class OrderHistory extends Component {
                       <Typography variant="body2">Order Total</Typography>
                       <div>
                         <Typography variant="body1">
-                          ${order.orderCost}
+                          ${orderCost}
                         </Typography>
                       </div>
                     </TableCell>
@@ -94,6 +95,7 @@ class OrderHistory extends Component {
                 </TableHead>
                 <TableBody>
                   {order.bikes.map(bike => {
+                    const price=bike.orderEntries.price/100.00
                     return (
                       <TableRow key={bike.id}>
                         <TableCell
@@ -110,7 +112,7 @@ class OrderHistory extends Component {
                         </TableCell>
                         <TableCell>
                           <Link to={`/bikes/${bike.id}`}>{bike.name}</Link>
-                          <div>${bike.orderEntries.price}</div>
+                          <div>${price}</div>
                           <div>Quantity {bike.orderEntries.quantity}</div>
                         </TableCell>
                         <TableCell>

--- a/client/components/admin/Orders.js
+++ b/client/components/admin/Orders.js
@@ -58,7 +58,7 @@ class Orders extends Component {
               <div className={classes.summary}>
                 <div>Order Id: {order.id}</div>
                 <div>Status: {order.state}</div>
-                <div>Total Cost: {order.orderCost}</div>
+                <div>Total Cost: {order.orderCost/100.00}</div>
               </div>
             </ExpansionPanelSummary>
             <ExpansionPanelDetails>


### PR DESCRIPTION
Order  and order entries tables were created int, so they're in cents.

WIth this change, we can now see all order-related stuff on components in dollars (/100)